### PR TITLE
Adding a workflow for tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,10 @@
+name: Tests
+on: [push]
+jobs:
+  Unit-Tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - run: cmake -P test_parse_file_options.cmake


### PR DESCRIPTION
Cmake is supposed to work the same on every platform, so I only test on ubuntu-latest.
It only runs `test_parse_file_options.cmake` because it is the only one that is supposed to pass as of the base revision.